### PR TITLE
frameworks: Add header for Fresh

### DIFF
--- a/ingredients/frameworks/fresh.json
+++ b/ingredients/frameworks/fresh.json
@@ -1,25 +1,30 @@
 {
-    "name": "Fresh JS",
-    "description": "Fresh is a full stack web framework for JavaScript and TypeScript developers, designed to make it trivial to create high-quality, performant, and personalized web applications. It is built on top of Deno.",
-    "icon": "/icon/fresh-js.png",
-    "checks": {
-        "tags": [
-            {
-                "tag": "link",
-                "attribute": "href",
-                "value": "/_frsh/*.css"
-            },
-            {
-                "tag": "script",
-                "attribute": "src",
-                "value": "/_frsh/*.js"
-            },
-            {
-                "tag": "script",
-                "attribute": "id",
-                "value": "__FRSH"
-            }
-        ],
-        "headers": []
-    }
+  "name": "Fresh",
+  "description": "Fresh is a full stack web framework for JavaScript and TypeScript developers, designed to make it trivial to create high-quality, performant, and personalized web applications. It is built on top of Deno.",
+  "icon": "/icon/fresh-js.png",
+  "checks": {
+    "tags": [
+      {
+        "tag": "link",
+        "attribute": "href",
+        "value": "/_frsh/*.css"
+      },
+      {
+        "tag": "script",
+        "attribute": "src",
+        "value": "/_frsh/*.js"
+      },
+      {
+        "tag": "script",
+        "attribute": "id",
+        "value": "__FRSH"
+      }
+    ],
+    "headers": [
+      {
+        "header": "x-fresh-uuid",
+        "value": null
+      }
+    ]
+  }
 }


### PR DESCRIPTION
- Added header for checking for Fresh framework, because the other checks only work
  if you have client-side JavaScript generated by Fresh.
- Renamed from Fresh.js to Fresh, because the framework is simply called Fresh.

You can test with <http://deno.com> (has client-side JS) and my website
<https://timharek.no> (no client-side JS).
